### PR TITLE
Fix [, [[ pages

### DIFF
--- a/common/[.clip
+++ b/common/[.clip
@@ -16,9 +16,13 @@
 
 `[ {string operator: -z, -n} "${string variable: foo}" ]`
 
-- Test if a specific [f]ile/[d]irectory exists:
+- Test if a specific [f]ile exists:
 
-`[ {string operator: -f, -d} {/?file some: ~/.bashrc} ]`
+`[ -f {/?file some: ~/.bashrc} ]`
+
+- Test if a specific [d]irectory exists:
+
+`[ -d {/?directory some: images} ]`
 
 - Test if a specific file or directory [e]xists:
 

--- a/common/[[.clip
+++ b/common/[[.clip
@@ -16,9 +16,13 @@
 
 `[[ {string operator: -z, -n} "${string variable: foo}" ]]`
 
-- Test if a specific [f]ile/[d]irectory exists:
+- Test if a specific [f]ile exists:
 
-`[[ {string operator: -f, -d} {/?file some: ~/.bashrc} ]]`
+`[[ -f {/?file some: ~/.bashrc} ]]`
+
+- Test if a specific [d]irectory exists:
+
+`[[ -d {/?directory some: images} ]]`
 
 - Test if a specific file or directory [e]xists:
 


### PR DESCRIPTION
- don't combine -f and -d option examples as their interpretation is incorrect with such syntax: expect -f or -d and file or directory than (which implies that -d can accept regular file according to this syntax as all placeholders are independent)