### PR TITLE
Remove all alias pages as they are unsupported

### DIFF
--- a/common/bundler.clip
+++ b/common/bundler.clip
@@ -1,9 +1,0 @@
-# bundler
-
-> Dependency manager for the Ruby programming language
-> `bundler` is a common name for the command `bundle`, but not a command itself
-> More information: https://bundler.io/man/bundle.1.html
-
-- View documentation for the original command:
-
-`tldr bundle`

--- a/common/clang-cpp.clip
+++ b/common/clang-cpp.clip
@@ -1,7 +1,0 @@
-# clang-cpp
-
-> This command is an alias of `clang++`
-
-- View documentation for the original command:
-
-`tldr clang++`

--- a/common/clojure.clip
+++ b/common/clojure.clip
@@ -1,7 +1,0 @@
-# clojure
-
-> This command is an alias of `clj`
-
-- View documentation for the original command:
-
-`tldr clj`

--- a/common/cola.clip
+++ b/common/cola.clip
@@ -1,7 +1,0 @@
-# cola
-
-> This command is an alias of `git-cola`
-
-- View documentation for the original command:
-
-`tldr git-cola`

--- a/common/cron.clip
+++ b/common/cron.clip
@@ -1,8 +1,0 @@
-# cron
-
-> `cron` is a system scheduler for running jobs or tasks unattended
-> The command to submit, edit or delete entries to `cron` is called `crontab`
-
-- View documentation for the original command:
-
-`tldr crontab`

--- a/common/fossil-ci.clip
+++ b/common/fossil-ci.clip
@@ -1,8 +1,0 @@
-# fossil ci
-
-> This command is an alias of `fossil commit`
-> More information: https://fossil-scm.org/home/help/commit
-
-- View documentation for the original command:
-
-`tldr fossil-commit`

--- a/common/fossil-delete.clip
+++ b/common/fossil-delete.clip
@@ -1,8 +1,0 @@
-# fossil delete
-
-> This command is an alias of `fossil rm`
-> More information: https://fossil-scm.org/home/help/delete
-
-- View documentation for the original command:
-
-`tldr fossil rm`

--- a/common/fossil-forget.clip
+++ b/common/fossil-forget.clip
@@ -1,8 +1,0 @@
-# fossil forget
-
-> This command is an alias of `fossil rm`, with the exception that it never removes files from the disk
-> More information: https://fossil-scm.org/home/help/forget
-
-- View documentation for the original command:
-
-`tldr fossil rm`

--- a/common/fossil-new.clip
+++ b/common/fossil-new.clip
@@ -1,8 +1,0 @@
-# fossil new
-
-> This command is an alias of `fossil init`
-> More information: https://fossil-scm.org/home/help/new
-
-- View documentation for the original command:
-
-`tldr fossil-init`

--- a/common/gh-cs.clip
+++ b/common/gh-cs.clip
@@ -1,8 +1,0 @@
-# gh cs
-
-> This command is an alias of `gh codespace`
-> More information: https://cli.github.com/manual/gh_codespace
-
-- View documentation for the original command:
-
-`tldr gh-codespace`

--- a/common/gnmic-sub.clip
+++ b/common/gnmic-sub.clip
@@ -1,8 +1,0 @@
-# gnmic sub
-
-> This command is an alias of `gnmic subscribe`
-> More information: https://gnmic.kmrd.dev/cmd/subscribe
-
-- View documentation for the original command:
-
-`tldr gnmic subscribe`

--- a/common/google-chrome.clip
+++ b/common/google-chrome.clip
@@ -1,8 +1,0 @@
-# google-chrome
-
-> This command is an alias of `chromium`
-> More information: https://chrome.google.com
-
-- View documentation for the original command:
-
-`tldr chromium`

--- a/common/hx.clip
+++ b/common/hx.clip
@@ -1,7 +1,0 @@
-# hx
-
-> This command is an alias of `helix`
-
-- View documentation for the original command:
-
-`tldr helix`

--- a/common/kafkacat.clip
+++ b/common/kafkacat.clip
@@ -1,7 +1,0 @@
-# kafkacat
-
-> This command is an alias of `kcat`
-
-- View documentation for the original command:
-
-`tldr kcat`

--- a/common/llvm-ar.clip
+++ b/common/llvm-ar.clip
@@ -1,7 +1,0 @@
-# llvm-ar
-
-> This command is an alias of `ar`
-
-- View documentation for the original command:
-
-`tldr ar`

--- a/common/llvm-g++.clip
+++ b/common/llvm-g++.clip
@@ -1,7 +1,0 @@
-# llvm-g++
-
-> This command is an alias of `clang++`
-
-- View documentation for the original command:
-
-`tldr clang++`

--- a/common/llvm-gcc.clip
+++ b/common/llvm-gcc.clip
@@ -1,7 +1,0 @@
-# llvm-gcc
-
-> This command is an alias of `clang`
-
-- View documentation for the original command:
-
-`tldr clang`

--- a/common/llvm-nm.clip
+++ b/common/llvm-nm.clip
@@ -1,7 +1,0 @@
-# llvm-nm
-
-> This command is an alias of `nm`
-
-- View documentation for the original command:
-
-`tldr nm`

--- a/common/llvm-objdump.clip
+++ b/common/llvm-objdump.clip
@@ -1,7 +1,0 @@
-# llvm-objdump
-
-> This command is an alias of `objdump`
-
-- View documentation for the original command:
-
-`tldr objdump`

--- a/common/llvm-strings.clip
+++ b/common/llvm-strings.clip
@@ -1,7 +1,0 @@
-# llvm-strings
-
-> This command is an alias of `strings`
-
-- View documentation for the original command:
-
-`tldr strings`

--- a/common/lzcat.clip
+++ b/common/lzcat.clip
@@ -1,8 +1,0 @@
-# lzcat
-
-> This command is an alias of `xz --format=lzma --decompress --stdout`
-> More information: https://manned.org/lzcat
-
-- View documentation for the original command:
-
-`tldr xz`

--- a/common/lzma.clip
+++ b/common/lzma.clip
@@ -1,8 +1,0 @@
-# lzma
-
-> This command is an alias of `xz --format=lzma`
-> More information: https://manned.org/lzma
-
-- View documentation for the original command:
-
-`tldr xz`

--- a/common/mscore.clip
+++ b/common/mscore.clip
@@ -1,8 +1,0 @@
-# mscore
-
-> This command is an alias of `musescore`
-> More information: https://musescore.org/handbook/command-line-options
-
-- View documentation for the original command:
-
-`tldr musescore`

--- a/common/nm-classic.clip
+++ b/common/nm-classic.clip
@@ -1,7 +1,0 @@
-# nm-classic
-
-> This command is an alias of `nm`
-
-- View documentation for the original command:
-
-`tldr nm`

--- a/common/ntl.clip
+++ b/common/ntl.clip
@@ -1,8 +1,0 @@
-# ntl
-
-> This command is an alias of `netlify`
-> More information: https://cli.netlify.com
-
-- View documentation for the original command:
-
-`tldr netlify`

--- a/common/pio-init.clip
+++ b/common/pio-init.clip
@@ -1,7 +1,0 @@
-# pio init
-
-> This command is an alias of `pio project init`
-
-- View documentation for the original command:
-
-`tldr pio project`

--- a/common/piodebuggdb.clip
+++ b/common/piodebuggdb.clip
@@ -1,7 +1,0 @@
-# piodebuggdb
-
-> This command is an alias of `pio debug --interface=gdb`
-
-- View documentation for the original command:
-
-`tldr pio debug`

--- a/common/platformio.clip
+++ b/common/platformio.clip
@@ -1,8 +1,0 @@
-# platformio
-
-> This command is an alias of `pio`
-> More information: https://docs.platformio.org/en/latest/core/userguide/
-
-- View documentation for the original command:
-
-`tldr pio`

--- a/common/ptpython3.clip
+++ b/common/ptpython3.clip
@@ -1,7 +1,0 @@
-# ptpython3
-
-> This command is an alias of `ptpython`
-
-- View documentation for the original command:
-
-`tldr ptpython`

--- a/common/python3.clip
+++ b/common/python3.clip
@@ -1,7 +1,0 @@
-# python3
-
-> This command is an alias of `python`
-
-- View documentation for the original command:
-
-`tldr python`

--- a/common/r2.clip
+++ b/common/r2.clip
@@ -1,7 +1,0 @@
-# r2
-
-> This command is an alias of `radare2`
-
-- View documentation for the original command:
-
-`tldr radare2`

--- a/common/rcat.clip
+++ b/common/rcat.clip
@@ -1,7 +1,0 @@
-# rcat
-
-> This command is an alias of `rc`
-
-- View documentation for the original command:
-
-`tldr rc`

--- a/common/ripgrep.clip
+++ b/common/ripgrep.clip
@@ -1,7 +1,0 @@
-# ripgrep
-
-> `ripgrep` is the common name for the command `rg`
-
-- View documentation for the original command:
-
-`tldr rg`

--- a/common/tldrl.clip
+++ b/common/tldrl.clip
@@ -1,8 +1,0 @@
-# tldrl
-
-> This command is an alias of `tldr-lint`
-> More information: https://github.com/tldr-pages/tldr-lint
-
-- View documentation for the original command:
-
-`tldr tldr-lint`

--- a/common/tlmgr-arch.clip
+++ b/common/tlmgr-arch.clip
@@ -1,8 +1,0 @@
-# tlmgr arch
-
-> This command is an alias of `tlmgr platform`
-> More information: https://www.tug.org/texlive/tlmgr.html
-
-- View documentation for the original command:
-
-`tldr tlmgr platform`

--- a/common/todoman.clip
+++ b/common/todoman.clip
@@ -1,9 +1,0 @@
-# todoman
-
-> A simple, standards-based, cli todo manager
-> `todoman` is a common name for the command `todo`, but not a command itself
-> More information: https://todoman.readthedocs.io/
-
-- View documentation for the original command:
-
-`tldr todo`

--- a/common/unlzma.clip
+++ b/common/unlzma.clip
@@ -1,8 +1,0 @@
-# unlzma
-
-> This command is an alias of `xz --format=lzma --decompress`
-> More information: https://manned.org/unlzma
-
-- View documentation for the original command:
-
-`tldr xz`

--- a/common/unxz.clip
+++ b/common/unxz.clip
@@ -1,8 +1,0 @@
-# unxz
-
-> This command is an alias of `xz --decompress`
-> More information: https://manned.org/unxz
-
-- View documentation for the original command:
-
-`tldr xz`

--- a/common/vi.clip
+++ b/common/vi.clip
@@ -1,7 +1,0 @@
-# vi
-
-> This command is an alias of `vim`
-
-- View documentation for the original command:
-
-`tldr vim`

--- a/common/xzcat.clip
+++ b/common/xzcat.clip
@@ -1,8 +1,0 @@
-# xzcat
-
-> This command is an alias of `xz --decompress --stdout`
-> More information: https://manned.org/xzcat
-
-- View documentation for the original command:
-
-`tldr xz`

--- a/linux/alternatives.clip
+++ b/linux/alternatives.clip
@@ -1,8 +1,0 @@
-# alternatives
-
-> This command is an alias of `update-alternatives`
-> More information: https://manned.org/alternatives
-
-- View documentation for the original command:
-
-`tldr update-alternatives`

--- a/linux/batcat.clip
+++ b/linux/batcat.clip
@@ -1,8 +1,0 @@
-# batcat
-
-> This command is an alias of `bat`
-> More information: https://github.com/sharkdp/bat
-
-- View documentation for the original command:
-
-`tldr bat`

--- a/linux/cc.clip
+++ b/linux/cc.clip
@@ -1,8 +1,0 @@
-# cc
-
-> This command is an alias of `gcc`
-> More information: https://gcc.gnu.org
-
-- View documentation for the original command:
-
-`tldr gcc`

--- a/linux/ip-route-list.clip
+++ b/linux/ip-route-list.clip
@@ -1,7 +1,0 @@
-# ip route list
-
-> This command is an alias of `ip route show`
-
-- View documentation for the original command:
-
-`tldr ip-route-show`

--- a/linux/megadl.clip
+++ b/linux/megadl.clip
@@ -1,8 +1,0 @@
-# megadl
-
-> This command is an alias of `megatools-dl`
-> More information: https://megatools.megous.com/man/megatools-dl.html
-
-- View documentation for the original command:
-
-`tldr megatools-dl`

--- a/linux/ncal.clip
+++ b/linux/ncal.clip
@@ -1,8 +1,0 @@
-# ncal
-
-> This command is an alias of `cal`
-> More information: https://manned.org/ncal
-
-- View documentation for the original command:
-
-`tldr cal`

--- a/linux/ubuntu-bug.clip
+++ b/linux/ubuntu-bug.clip
@@ -1,8 +1,0 @@
-# ubuntu-bug
-
-> This command is an alias of `apport-bug`
-> More information: https://manned.org/ubuntu-bug
-
-- View documentation for the original command:
-
-`tldr apport-bug`

--- a/osx/aa.clip
+++ b/osx/aa.clip
@@ -1,7 +1,0 @@
-# aa
-
-> This command is an alias of `yaa`
-
-- View documentation for the original command:
-
-`tldr yaa`

--- a/osx/g[.clip
+++ b/osx/g[.clip
@@ -1,7 +1,0 @@
-# g[
-
-> This command is an alias of GNU `[`
-
-- View documentation for the original command:
-
-`tldr -p linux [`

--- a/osx/gawk.clip
+++ b/osx/gawk.clip
@@ -1,7 +1,0 @@
-# gawk
-
-> This command is an alias of GNU `awk`
-
-- View documentation for the original command:
-
-`tldr -p linux awk`

--- a/osx/gb2sum.clip
+++ b/osx/gb2sum.clip
@@ -1,7 +1,0 @@
-# gb2sum
-
-> This command is an alias of GNU `b2sum`
-
-- View documentation for the original command:
-
-`tldr -p linux b2sum`

--- a/osx/gbase32.clip
+++ b/osx/gbase32.clip
@@ -1,7 +1,0 @@
-# gbase32
-
-> This command is an alias of GNU `base32`
-
-- View documentation for the original command:
-
-`tldr -p linux base32`

--- a/osx/gbase64.clip
+++ b/osx/gbase64.clip
@@ -1,7 +1,0 @@
-# gbase64
-
-> This command is an alias of GNU `base64`
-
-- View documentation for the original command:
-
-`tldr -p linux base64`

--- a/osx/gbasename.clip
+++ b/osx/gbasename.clip
@@ -1,7 +1,0 @@
-# gbasename
-
-> This command is an alias of GNU `basename`
-
-- View documentation for the original command:
-
-`tldr -p linux basename`

--- a/osx/gbasenc.clip
+++ b/osx/gbasenc.clip
@@ -1,7 +1,0 @@
-# gbasenc
-
-> This command is an alias of GNU `basenc`
-
-- View documentation for the original command:
-
-`tldr -p linux basenc`

--- a/osx/gcat.clip
+++ b/osx/gcat.clip
@@ -1,7 +1,0 @@
-# gcat
-
-> This command is an alias of GNU `cat`
-
-- View documentation for the original command:
-
-`tldr -p linux cat`

--- a/osx/gchcon.clip
+++ b/osx/gchcon.clip
@@ -1,7 +1,0 @@
-# gchcon
-
-> This command is an alias of GNU `chcon`
-
-- View documentation for the original command:
-
-`tldr -p linux chcon`

--- a/osx/gchgrp.clip
+++ b/osx/gchgrp.clip
@@ -1,7 +1,0 @@
-# gchgrp
-
-> This command is an alias of GNU `chgrp`
-
-- View documentation for the original command:
-
-`tldr -p linux chgrp`

--- a/osx/gchmod.clip
+++ b/osx/gchmod.clip
@@ -1,7 +1,0 @@
-# gchmod
-
-> This command is an alias of GNU `chmod`
-
-- View documentation for the original command:
-
-`tldr -p linux chmod`

--- a/osx/gchown.clip
+++ b/osx/gchown.clip
@@ -1,7 +1,0 @@
-# gchown
-
-> This command is an alias of GNU `chown`
-
-- View documentation for the original command:
-
-`tldr -p linux chown`

--- a/osx/gchroot.clip
+++ b/osx/gchroot.clip
@@ -1,7 +1,0 @@
-# gchroot
-
-> This command is an alias of GNU `chroot`
-
-- View documentation for the original command:
-
-`tldr -p linux chroot`

--- a/osx/gcksum.clip
+++ b/osx/gcksum.clip
@@ -1,7 +1,0 @@
-# gcksum
-
-> This command is an alias of GNU `cksum`
-
-- View documentation for the original command:
-
-`tldr -p linux cksum`

--- a/osx/gcomm.clip
+++ b/osx/gcomm.clip
@@ -1,7 +1,0 @@
-# gcomm
-
-> This command is an alias of GNU `comm`
-
-- View documentation for the original command:
-
-`tldr -p linux comm`

--- a/osx/gcp.clip
+++ b/osx/gcp.clip
@@ -1,7 +1,0 @@
-# gcp
-
-> This command is an alias of GNU `cp`
-
-- View documentation for the original command:
-
-`tldr -p linux cp`

--- a/osx/gcsplit.clip
+++ b/osx/gcsplit.clip
@@ -1,7 +1,0 @@
-# gcsplit
-
-> This command is an alias of GNU `csplit`
-
-- View documentation for the original command:
-
-`tldr -p linux csplit`

--- a/osx/gcut.clip
+++ b/osx/gcut.clip
@@ -1,7 +1,0 @@
-# gcut
-
-> This command is an alias of GNU `cut`
-
-- View documentation for the original command:
-
-`tldr -p linux cut`

--- a/osx/gdate.clip
+++ b/osx/gdate.clip
@@ -1,7 +1,0 @@
-# gdate
-
-> This command is an alias of GNU `date`
-
-- View documentation for the original command:
-
-`tldr -p linux date`

--- a/osx/gdd.clip
+++ b/osx/gdd.clip
@@ -1,7 +1,0 @@
-# gdd
-
-> This command is an alias of GNU `dd`
-
-- View documentation for the original command:
-
-`tldr -p linux dd`

--- a/osx/gdf.clip
+++ b/osx/gdf.clip
@@ -1,7 +1,0 @@
-# gdf
-
-> This command is an alias of GNU `df`
-
-- View documentation for the original command:
-
-`tldr -p linux df`

--- a/osx/gdir.clip
+++ b/osx/gdir.clip
@@ -1,7 +1,0 @@
-# gdir
-
-> This command is an alias of GNU `dir`
-
-- View documentation for the original command:
-
-`tldr -p linux dir`

--- a/osx/gdircolors.clip
+++ b/osx/gdircolors.clip
@@ -1,7 +1,0 @@
-# gdircolors
-
-> This command is an alias of GNU `dircolors`
-
-- View documentation for the original command:
-
-`tldr -p linux dircolors`

--- a/osx/gdirname.clip
+++ b/osx/gdirname.clip
@@ -1,7 +1,0 @@
-# gdirname
-
-> This command is an alias of GNU `dirname`
-
-- View documentation for the original command:
-
-`tldr -p linux dirname`

--- a/osx/gdnsdomainname.clip
+++ b/osx/gdnsdomainname.clip
@@ -1,7 +1,0 @@
-# gdnsdomainname
-
-> This command is an alias of GNU `dnsdomainname`
-
-- View documentation for the original command:
-
-`tldr -p linux dnsdomainname`

--- a/osx/gecho.clip
+++ b/osx/gecho.clip
@@ -1,7 +1,0 @@
-# gecho
-
-> This command is an alias of GNU `echo`
-
-- View documentation for the original command:
-
-`tldr -p linux echo`

--- a/osx/ged.clip
+++ b/osx/ged.clip
@@ -1,7 +1,0 @@
-# ged
-
-> This command is an alias of GNU `ed`
-
-- View documentation for the original command:
-
-`tldr -p linux ed`

--- a/osx/gegrep.clip
+++ b/osx/gegrep.clip
@@ -1,7 +1,0 @@
-# gegrep
-
-> This command is an alias of GNU `egrep`
-
-- View documentation for the original command:
-
-`tldr -p linux egrep`

--- a/osx/genv.clip
+++ b/osx/genv.clip
@@ -1,7 +1,0 @@
-# genv
-
-> This command is an alias of GNU `env`
-
-- View documentation for the original command:
-
-`tldr -p linux env`

--- a/osx/gexpand.clip
+++ b/osx/gexpand.clip
@@ -1,7 +1,0 @@
-# gexpand
-
-> This command is an alias of GNU `expand`
-
-- View documentation for the original command:
-
-`tldr -p linux expand`

--- a/osx/gexpr.clip
+++ b/osx/gexpr.clip
@@ -1,7 +1,0 @@
-# gexpr
-
-> This command is an alias of GNU `expr`
-
-- View documentation for the original command:
-
-`tldr -p linux expr`

--- a/osx/gfactor.clip
+++ b/osx/gfactor.clip
@@ -1,7 +1,0 @@
-# gfactor
-
-> This command is an alias of GNU `factor`
-
-- View documentation for the original command:
-
-`tldr -p linux factor`

--- a/osx/gfalse.clip
+++ b/osx/gfalse.clip
@@ -1,7 +1,0 @@
-# gfalse
-
-> This command is an alias of GNU `false`
-
-- View documentation for the original command:
-
-`tldr -p linux false`

--- a/osx/gfgrep.clip
+++ b/osx/gfgrep.clip
@@ -1,7 +1,0 @@
-# gfgrep
-
-> This command is an alias of GNU `fgrep`
-
-- View documentation for the original command:
-
-`tldr -p linux fgrep`

--- a/osx/gfind.clip
+++ b/osx/gfind.clip
@@ -1,7 +1,0 @@
-# gfind
-
-> This command is an alias of GNU `find`
-
-- View documentation for the original command:
-
-`tldr -p linux find`

--- a/osx/gfmt.clip
+++ b/osx/gfmt.clip
@@ -1,7 +1,0 @@
-# gfmt
-
-> This command is an alias of GNU `fmt`
-
-- View documentation for the original command:
-
-`tldr -p linux fmt`

--- a/osx/gfold.clip
+++ b/osx/gfold.clip
@@ -1,7 +1,0 @@
-# gfold
-
-> This command is an alias of GNU `fold`
-
-- View documentation for the original command:
-
-`tldr -p linux fold`

--- a/osx/gftp.clip
+++ b/osx/gftp.clip
@@ -1,7 +1,0 @@
-# gftp
-
-> This command is an alias of GNU `ftp`
-
-- View documentation for the original command:
-
-`tldr -p linux ftp`

--- a/osx/ggrep.clip
+++ b/osx/ggrep.clip
@@ -1,7 +1,0 @@
-# ggrep
-
-> This command is an alias of GNU `grep`
-
-- View documentation for the original command:
-
-`tldr -p linux grep`

--- a/osx/ggroups.clip
+++ b/osx/ggroups.clip
@@ -1,7 +1,0 @@
-# ggroups
-
-> This command is an alias of GNU `groups`
-
-- View documentation for the original command:
-
-`tldr -p linux groups`

--- a/osx/ghead.clip
+++ b/osx/ghead.clip
@@ -1,7 +1,0 @@
-# ghead
-
-> This command is an alias of GNU `head`
-
-- View documentation for the original command:
-
-`tldr -p linux head`

--- a/osx/ghostid.clip
+++ b/osx/ghostid.clip
@@ -1,7 +1,0 @@
-# ghostid
-
-> This command is an alias of GNU `hostid`
-
-- View documentation for the original command:
-
-`tldr -p linux hostid`

--- a/osx/ghostname.clip
+++ b/osx/ghostname.clip
@@ -1,7 +1,0 @@
-# ghostname
-
-> This command is an alias of GNU `hostname`
-
-- View documentation for the original command:
-
-`tldr -p linux hostname`

--- a/osx/gid.clip
+++ b/osx/gid.clip
@@ -1,7 +1,0 @@
-# gid
-
-> This command is an alias of GNU `id`
-
-- View documentation for the original command:
-
-`tldr -p linux id`

--- a/osx/gifconfig.clip
+++ b/osx/gifconfig.clip
@@ -1,7 +1,0 @@
-# gifconfig
-
-> This command is an alias of GNU `ifconfig`
-
-- View documentation for the original command:
-
-`tldr -p linux ifconfig`

--- a/osx/gindent.clip
+++ b/osx/gindent.clip
@@ -1,7 +1,0 @@
-# gindent
-
-> This command is an alias of GNU `indent`
-
-- View documentation for the original command:
-
-`tldr -p linux indent`

--- a/osx/ginstall.clip
+++ b/osx/ginstall.clip
@@ -1,7 +1,0 @@
-# ginstall
-
-> This command is an alias of GNU `install`
-
-- View documentation for the original command:
-
-`tldr -p linux install`

--- a/osx/gjoin.clip
+++ b/osx/gjoin.clip
@@ -1,7 +1,0 @@
-# gjoin
-
-> This command is an alias of GNU `join`
-
-- View documentation for the original command:
-
-`tldr -p linux join`

--- a/osx/gkill.clip
+++ b/osx/gkill.clip
@@ -1,7 +1,0 @@
-# gkill
-
-> This command is an alias of GNU `kill`
-
-- View documentation for the original command:
-
-`tldr -p linux kill`

--- a/osx/glibtool.clip
+++ b/osx/glibtool.clip
@@ -1,7 +1,0 @@
-# glibtool
-
-> This command is an alias of GNU `libtool`
-
-- View documentation for the original command:
-
-`tldr -p linux libtool`

--- a/osx/glibtoolize.clip
+++ b/osx/glibtoolize.clip
@@ -1,7 +1,0 @@
-# glibtoolize
-
-> This command is an alias of GNU `libtoolize`
-
-- View documentation for the original command:
-
-`tldr -p linux libtoolize`

--- a/osx/glink.clip
+++ b/osx/glink.clip
@@ -1,7 +1,0 @@
-# glink
-
-> This command is an alias of GNU `link`
-
-- View documentation for the original command:
-
-`tldr -p linux link`

--- a/osx/gln.clip
+++ b/osx/gln.clip
@@ -1,7 +1,0 @@
-# gln
-
-> This command is an alias of GNU `ln`
-
-- View documentation for the original command:
-
-`tldr -p linux ln`

--- a/osx/glocate.clip
+++ b/osx/glocate.clip
@@ -1,7 +1,0 @@
-# glocate
-
-> This command is an alias of GNU `locate`
-
-- View documentation for the original command:
-
-`tldr -p linux locate`

--- a/osx/glogger.clip
+++ b/osx/glogger.clip
@@ -1,7 +1,0 @@
-# glogger
-
-> This command is an alias of GNU `logger`
-
-- View documentation for the original command:
-
-`tldr -p linux logger`

--- a/osx/glogname.clip
+++ b/osx/glogname.clip
@@ -1,7 +1,0 @@
-# glogname
-
-> This command is an alias of GNU `logname`
-
-- View documentation for the original command:
-
-`tldr -p linux logname`

--- a/osx/gls.clip
+++ b/osx/gls.clip
@@ -1,7 +1,0 @@
-# gls
-
-> This command is an alias of GNU `ls`
-
-- View documentation for the original command:
-
-`tldr -p linux ls`

--- a/osx/gmake.clip
+++ b/osx/gmake.clip
@@ -1,7 +1,0 @@
-# gmake
-
-> This command is an alias of GNU `make`
-
-- View documentation for the original command:
-
-`tldr -p linux make`

--- a/osx/gmd5sum.clip
+++ b/osx/gmd5sum.clip
@@ -1,7 +1,0 @@
-# gmd5sum
-
-> This command is an alias of GNU `md5sum`
-
-- View documentation for the original command:
-
-`tldr -p linux md5sum`

--- a/osx/gmkdir.clip
+++ b/osx/gmkdir.clip
@@ -1,7 +1,0 @@
-# gmkdir
-
-> This command is an alias of GNU `mkdir`
-
-- View documentation for the original command:
-
-`tldr -p linux mkdir`

--- a/osx/gmkfifo.clip
+++ b/osx/gmkfifo.clip
@@ -1,7 +1,0 @@
-# gmkfifo
-
-> This command is an alias of GNU `mkfifo`
-
-- View documentation for the original command:
-
-`tldr -p linux mkfifo`

--- a/osx/gmknod.clip
+++ b/osx/gmknod.clip
@@ -1,7 +1,0 @@
-# gmknod
-
-> This command is an alias of GNU `mknod`
-
-- View documentation for the original command:
-
-`tldr -p linux mknod`

--- a/osx/gmktemp.clip
+++ b/osx/gmktemp.clip
@@ -1,7 +1,0 @@
-# gmktemp
-
-> This command is an alias of GNU `mktemp`
-
-- View documentation for the original command:
-
-`tldr -p linux mktemp`

--- a/osx/gmv.clip
+++ b/osx/gmv.clip
@@ -1,7 +1,0 @@
-# gmv
-
-> This command is an alias of GNU `mv`
-
-- View documentation for the original command:
-
-`tldr -p linux mv`

--- a/osx/gnice.clip
+++ b/osx/gnice.clip
@@ -1,7 +1,0 @@
-# gnice
-
-> This command is an alias of GNU `nice`
-
-- View documentation for the original command:
-
-`tldr -p linux nice`

--- a/osx/gnl.clip
+++ b/osx/gnl.clip
@@ -1,7 +1,0 @@
-# gnl
-
-> This command is an alias of GNU `nl`
-
-- View documentation for the original command:
-
-`tldr -p linux nl`

--- a/osx/gnohup.clip
+++ b/osx/gnohup.clip
@@ -1,7 +1,0 @@
-# gnohup
-
-> This command is an alias of GNU `nohup`
-
-- View documentation for the original command:
-
-`tldr -p linux nohup`

--- a/osx/gnproc.clip
+++ b/osx/gnproc.clip
@@ -1,7 +1,0 @@
-# gnproc
-
-> This command is an alias of GNU `nproc`
-
-- View documentation for the original command:
-
-`tldr -p linux nproc`

--- a/osx/gnumfmt.clip
+++ b/osx/gnumfmt.clip
@@ -1,7 +1,0 @@
-# gnumfmt
-
-> This command is an alias of GNU `numfmt`
-
-- View documentation for the original command:
-
-`tldr -p linux numfmt`

--- a/osx/god.clip
+++ b/osx/god.clip
@@ -1,7 +1,0 @@
-# god
-
-> This command is an alias of GNU `od`
-
-- View documentation for the original command:
-
-`tldr -p linux od`

--- a/osx/gpaste.clip
+++ b/osx/gpaste.clip
@@ -1,7 +1,0 @@
-# gpaste
-
-> This command is an alias of GNU `paste`
-
-- View documentation for the original command:
-
-`tldr -p linux paste`

--- a/osx/gpathchk.clip
+++ b/osx/gpathchk.clip
@@ -1,7 +1,0 @@
-# gpathchk
-
-> This command is an alias of GNU `pathchk`
-
-- View documentation for the original command:
-
-`tldr -p linux pathchk`

--- a/osx/gping.clip
+++ b/osx/gping.clip
@@ -1,7 +1,0 @@
-# gping
-
-> This command is an alias of GNU `ping`
-
-- View documentation for the original command:
-
-`tldr -p linux ping`

--- a/osx/gping6.clip
+++ b/osx/gping6.clip
@@ -1,7 +1,0 @@
-# gping6
-
-> This command is an alias of GNU `ping6`
-
-- View documentation for the original command:
-
-`tldr -p linux ping6`

--- a/osx/gpinky.clip
+++ b/osx/gpinky.clip
@@ -1,7 +1,0 @@
-# gpinky
-
-> This command is an alias of GNU `pinky`
-
-- View documentation for the original command:
-
-`tldr -p linux pinky`

--- a/osx/gpr.clip
+++ b/osx/gpr.clip
@@ -1,7 +1,0 @@
-# gpr
-
-> This command is an alias of GNU `pr`
-
-- View documentation for the original command:
-
-`tldr -p linux pr`

--- a/osx/gprintenv.clip
+++ b/osx/gprintenv.clip
@@ -1,7 +1,0 @@
-# gprintenv
-
-> This command is an alias of GNU `printenv`
-
-- View documentation for the original command:
-
-`tldr -p linux printenv`

--- a/osx/gprintf.clip
+++ b/osx/gprintf.clip
@@ -1,7 +1,0 @@
-# gprintf
-
-> This command is an alias of GNU `printf`
-
-- View documentation for the original command:
-
-`tldr -p linux printf`

--- a/osx/gptx.clip
+++ b/osx/gptx.clip
@@ -1,7 +1,0 @@
-# gptx
-
-> This command is an alias of GNU `ptx`
-
-- View documentation for the original command:
-
-`tldr -p linux ptx`

--- a/osx/gpwd.clip
+++ b/osx/gpwd.clip
@@ -1,7 +1,0 @@
-# gpwd
-
-> This command is an alias of GNU `pwd`
-
-- View documentation for the original command:
-
-`tldr -p linux pwd`

--- a/osx/grcp.clip
+++ b/osx/grcp.clip
@@ -1,7 +1,0 @@
-# grcp
-
-> This command is an alias of GNU `rcp`
-
-- View documentation for the original command:
-
-`tldr -p linux rcp`

--- a/osx/greadlink.clip
+++ b/osx/greadlink.clip
@@ -1,7 +1,0 @@
-# greadlink
-
-> This command is an alias of GNU `readlink`
-
-- View documentation for the original command:
-
-`tldr -p linux readlink`

--- a/osx/grealpath.clip
+++ b/osx/grealpath.clip
@@ -1,7 +1,0 @@
-# grealpath
-
-> This command is an alias of GNU `realpath`
-
-- View documentation for the original command:
-
-`tldr -p linux realpath`

--- a/osx/grexec.clip
+++ b/osx/grexec.clip
@@ -1,7 +1,0 @@
-# grexec
-
-> This command is an alias of GNU `rexec`
-
-- View documentation for the original command:
-
-`tldr -p linux rexec`

--- a/osx/grlogin.clip
+++ b/osx/grlogin.clip
@@ -1,7 +1,0 @@
-# grlogin
-
-> This command is an alias of GNU `rlogin`
-
-- View documentation for the original command:
-
-`tldr -p linux rlogin`

--- a/osx/grm.clip
+++ b/osx/grm.clip
@@ -1,7 +1,0 @@
-# grm
-
-> This command is an alias of GNU `rm`
-
-- View documentation for the original command:
-
-`tldr -p linux rm`

--- a/osx/grmdir.clip
+++ b/osx/grmdir.clip
@@ -1,7 +1,0 @@
-# grmdir
-
-> This command is an alias of GNU `rmdir`
-
-- View documentation for the original command:
-
-`tldr -p linux rmdir`

--- a/osx/grsh.clip
+++ b/osx/grsh.clip
@@ -1,7 +1,0 @@
-# grsh
-
-> This command is an alias of GNU `rsh`
-
-- View documentation for the original command:
-
-`tldr -p linux rsh`

--- a/osx/gruncon.clip
+++ b/osx/gruncon.clip
@@ -1,7 +1,0 @@
-# gruncon
-
-> This command is an alias of GNU `runcon`
-
-- View documentation for the original command:
-
-`tldr -p linux runcon`

--- a/osx/gsed.clip
+++ b/osx/gsed.clip
@@ -1,7 +1,0 @@
-# gsed
-
-> This command is an alias of GNU `sed`
-
-- View documentation for the original command:
-
-`tldr -p linux sed`

--- a/osx/gseq.clip
+++ b/osx/gseq.clip
@@ -1,7 +1,0 @@
-# gseq
-
-> This command is an alias of GNU `seq`
-
-- View documentation for the original command:
-
-`tldr -p linux seq`

--- a/osx/gsha1sum.clip
+++ b/osx/gsha1sum.clip
@@ -1,7 +1,0 @@
-# gsha1sum
-
-> This command is an alias of GNU `sha1sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sha1sum`

--- a/osx/gsha224sum.clip
+++ b/osx/gsha224sum.clip
@@ -1,7 +1,0 @@
-# gsha224sum
-
-> This command is an alias of GNU `sha224sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sha224sum`

--- a/osx/gsha256sum.clip
+++ b/osx/gsha256sum.clip
@@ -1,7 +1,0 @@
-# gsha256sum
-
-> This command is an alias of GNU `sha256sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sha256sum`

--- a/osx/gsha384sum.clip
+++ b/osx/gsha384sum.clip
@@ -1,7 +1,0 @@
-# gsha384sum
-
-> This command is an alias of GNU `sha384sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sha384sum`

--- a/osx/gsha512sum.clip
+++ b/osx/gsha512sum.clip
@@ -1,7 +1,0 @@
-# gsha512sum
-
-> This command is an alias of GNU `sha512sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sha512sum`

--- a/osx/gshred.clip
+++ b/osx/gshred.clip
@@ -1,7 +1,0 @@
-# gshred
-
-> This command is an alias of GNU `shred`
-
-- View documentation for the original command:
-
-`tldr -p linux shred`

--- a/osx/gshuf.clip
+++ b/osx/gshuf.clip
@@ -1,7 +1,0 @@
-# gshuf
-
-> This command is an alias of GNU `shuf`
-
-- View documentation for the original command:
-
-`tldr -p linux shuf`

--- a/osx/gsleep.clip
+++ b/osx/gsleep.clip
@@ -1,7 +1,0 @@
-# gsleep
-
-> This command is an alias of GNU `sleep`
-
-- View documentation for the original command:
-
-`tldr -p linux sleep`

--- a/osx/gsort.clip
+++ b/osx/gsort.clip
@@ -1,7 +1,0 @@
-# gsort
-
-> This command is an alias of GNU `sort`
-
-- View documentation for the original command:
-
-`tldr -p linux sort`

--- a/osx/gsplit.clip
+++ b/osx/gsplit.clip
@@ -1,7 +1,0 @@
-# gsplit
-
-> This command is an alias of GNU `split`
-
-- View documentation for the original command:
-
-`tldr -p linux split`

--- a/osx/gstat.clip
+++ b/osx/gstat.clip
@@ -1,7 +1,0 @@
-# gstat
-
-> This command is an alias of GNU `stat`
-
-- View documentation for the original command:
-
-`tldr -p linux stat`

--- a/osx/gstdbuf.clip
+++ b/osx/gstdbuf.clip
@@ -1,7 +1,0 @@
-# gstdbuf
-
-> This command is an alias of GNU `stdbuf`
-
-- View documentation for the original command:
-
-`tldr -p linux stdbuf`

--- a/osx/gstty.clip
+++ b/osx/gstty.clip
@@ -1,7 +1,0 @@
-# gstty
-
-> This command is an alias of GNU `stty`
-
-- View documentation for the original command:
-
-`tldr -p linux stty`

--- a/osx/gsum.clip
+++ b/osx/gsum.clip
@@ -1,7 +1,0 @@
-# gsum
-
-> This command is an alias of GNU `sum`
-
-- View documentation for the original command:
-
-`tldr -p linux sum`

--- a/osx/gsync.clip
+++ b/osx/gsync.clip
@@ -1,7 +1,0 @@
-# gsync
-
-> This command is an alias of GNU `sync`
-
-- View documentation for the original command:
-
-`tldr -p linux sync`

--- a/osx/gtac.clip
+++ b/osx/gtac.clip
@@ -1,7 +1,0 @@
-# gtac
-
-> This command is an alias of GNU `tac`
-
-- View documentation for the original command:
-
-`tldr -p linux tac`

--- a/osx/gtail.clip
+++ b/osx/gtail.clip
@@ -1,7 +1,0 @@
-# gtail
-
-> This command is an alias of GNU `tail`
-
-- View documentation for the original command:
-
-`tldr -p linux tail`

--- a/osx/gtalk.clip
+++ b/osx/gtalk.clip
@@ -1,7 +1,0 @@
-# gtalk
-
-> This command is an alias of GNU `talk`
-
-- View documentation for the original command:
-
-`tldr -p linux talk`

--- a/osx/gtar.clip
+++ b/osx/gtar.clip
@@ -1,7 +1,0 @@
-# gtar
-
-> This command is an alias of GNU `tar`
-
-- View documentation for the original command:
-
-`tldr -p linux tar`

--- a/osx/gtee.clip
+++ b/osx/gtee.clip
@@ -1,7 +1,0 @@
-# gtee
-
-> This command is an alias of GNU `tee`
-
-- View documentation for the original command:
-
-`tldr -p linux tee`

--- a/osx/gtelnet.clip
+++ b/osx/gtelnet.clip
@@ -1,7 +1,0 @@
-# gtelnet
-
-> This command is an alias of GNU `telnet`
-
-- View documentation for the original command:
-
-`tldr -p linux telnet`

--- a/osx/gtest.clip
+++ b/osx/gtest.clip
@@ -1,7 +1,0 @@
-# gtest
-
-> This command is an alias of GNU `test`
-
-- View documentation for the original command:
-
-`tldr -p linux test`

--- a/osx/gtftp.clip
+++ b/osx/gtftp.clip
@@ -1,7 +1,0 @@
-# gtftp
-
-> This command is an alias of GNU `tftp`
-
-- View documentation for the original command:
-
-`tldr -p linux tftp`

--- a/osx/gtime.clip
+++ b/osx/gtime.clip
@@ -1,7 +1,0 @@
-# gtime
-
-> This command is an alias of GNU `time`
-
-- View documentation for the original command:
-
-`tldr -p linux time`

--- a/osx/gtimeout.clip
+++ b/osx/gtimeout.clip
@@ -1,7 +1,0 @@
-# gtimeout
-
-> This command is an alias of GNU `timeout`
-
-- View documentation for the original command:
-
-`tldr -p linux timeout`

--- a/osx/gtouch.clip
+++ b/osx/gtouch.clip
@@ -1,7 +1,0 @@
-# gtouch
-
-> This command is an alias of GNU `touch`
-
-- View documentation for the original command:
-
-`tldr -p linux touch`

--- a/osx/gtr.clip
+++ b/osx/gtr.clip
@@ -1,7 +1,0 @@
-# gtr
-
-> This command is an alias of GNU `tr`
-
-- View documentation for the original command:
-
-`tldr -p linux tr`

--- a/osx/gtraceroute.clip
+++ b/osx/gtraceroute.clip
@@ -1,7 +1,0 @@
-# gtraceroute
-
-> This command is an alias of GNU `traceroute`
-
-- View documentation for the original command:
-
-`tldr -p linux traceroute`

--- a/osx/gtrue.clip
+++ b/osx/gtrue.clip
@@ -1,7 +1,0 @@
-# gtrue
-
-> This command is an alias of GNU `true`
-
-- View documentation for the original command:
-
-`tldr -p linux true`

--- a/osx/gtruncate.clip
+++ b/osx/gtruncate.clip
@@ -1,7 +1,0 @@
-# gtruncate
-
-> This command is an alias of GNU `truncate`
-
-- View documentation for the original command:
-
-`tldr -p linux truncate`

--- a/osx/gtsort.clip
+++ b/osx/gtsort.clip
@@ -1,7 +1,0 @@
-# gtsort
-
-> This command is an alias of GNU `tsort`
-
-- View documentation for the original command:
-
-`tldr -p linux tsort`

--- a/osx/gtty.clip
+++ b/osx/gtty.clip
@@ -1,7 +1,0 @@
-# gtty
-
-> This command is an alias of GNU `tty`
-
-- View documentation for the original command:
-
-`tldr -p linux tty`

--- a/osx/guname.clip
+++ b/osx/guname.clip
@@ -1,7 +1,0 @@
-# guname
-
-> This command is an alias of GNU `uname`
-
-- View documentation for the original command:
-
-`tldr -p linux uname`

--- a/osx/gunexpand.clip
+++ b/osx/gunexpand.clip
@@ -1,7 +1,0 @@
-# gunexpand
-
-> This command is an alias of GNU `unexpand`
-
-- View documentation for the original command:
-
-`tldr -p linux unexpand`

--- a/osx/guniq.clip
+++ b/osx/guniq.clip
@@ -1,7 +1,0 @@
-# guniq
-
-> This command is an alias of GNU `uniq`
-
-- View documentation for the original command:
-
-`tldr -p linux uniq`

--- a/osx/gunits.clip
+++ b/osx/gunits.clip
@@ -1,7 +1,0 @@
-# gunits
-
-> This command is an alias of GNU `units`
-
-- View documentation for the original command:
-
-`tldr -p linux units`

--- a/osx/gunlink.clip
+++ b/osx/gunlink.clip
@@ -1,7 +1,0 @@
-# gunlink
-
-> This command is an alias of GNU `unlink`
-
-- View documentation for the original command:
-
-`tldr -p linux unlink`

--- a/osx/gupdatedb.clip
+++ b/osx/gupdatedb.clip
@@ -1,7 +1,0 @@
-# gupdatedb
-
-> This command is an alias of GNU `updatedb`
-
-- View documentation for the original command:
-
-`tldr -p linux updatedb`

--- a/osx/guptime.clip
+++ b/osx/guptime.clip
@@ -1,7 +1,0 @@
-# guptime
-
-> This command is an alias of GNU `uptime`
-
-- View documentation for the original command:
-
-`tldr -p linux uptime`

--- a/osx/gusers.clip
+++ b/osx/gusers.clip
@@ -1,7 +1,0 @@
-# gusers
-
-> This command is an alias of GNU `users`
-
-- View documentation for the original command:
-
-`tldr -p linux users`

--- a/osx/gvdir.clip
+++ b/osx/gvdir.clip
@@ -1,7 +1,0 @@
-# gvdir
-
-> This command is an alias of GNU `vdir`
-
-- View documentation for the original command:
-
-`tldr -p linux vdir`

--- a/osx/gwc.clip
+++ b/osx/gwc.clip
@@ -1,7 +1,0 @@
-# gwc
-
-> This command is an alias of GNU `wc`
-
-- View documentation for the original command:
-
-`tldr -p linux wc`

--- a/osx/gwhich.clip
+++ b/osx/gwhich.clip
@@ -1,7 +1,0 @@
-# gwhich
-
-> This command is an alias of GNU `which`
-
-- View documentation for the original command:
-
-`tldr -p linux which`

--- a/osx/gwho.clip
+++ b/osx/gwho.clip
@@ -1,7 +1,0 @@
-# gwho
-
-> This command is an alias of GNU `who`
-
-- View documentation for the original command:
-
-`tldr -p linux who`

--- a/osx/gwhoami.clip
+++ b/osx/gwhoami.clip
@@ -1,7 +1,0 @@
-# gwhoami
-
-> This command is an alias of GNU `whoami`
-
-- View documentation for the original command:
-
-`tldr -p linux whoami`

--- a/osx/gwhois.clip
+++ b/osx/gwhois.clip
@@ -1,7 +1,0 @@
-# gwhois
-
-> This command is an alias of GNU `whois`
-
-- View documentation for the original command:
-
-`tldr -p linux whois`

--- a/osx/gxargs.clip
+++ b/osx/gxargs.clip
@@ -1,7 +1,0 @@
-# gxargs
-
-> This command is an alias of GNU `xargs`
-
-- View documentation for the original command:
-
-`tldr -p linux xargs`

--- a/osx/gyes.clip
+++ b/osx/gyes.clip
@@ -1,7 +1,0 @@
-# gyes
-
-> This command is an alias of GNU `yes`
-
-- View documentation for the original command:
-
-`tldr -p linux yes`

--- a/windows/chrome.clip
+++ b/windows/chrome.clip
@@ -1,8 +1,0 @@
-# chrome
-
-> This command is an alias of `chromium`
-> More information: https://chrome.google.com
-
-- View documentation for the original command:
-
-`tldr chromium`

--- a/windows/cinst.clip
+++ b/windows/cinst.clip
@@ -1,8 +1,0 @@
-# cinst
-
-> This command is an alias of `choco install`
-> More information: https://docs.chocolatey.org/en-us/choco/commands/install
-
-- View documentation for the original command:
-
-`tldr choco install`

--- a/windows/clist.clip
+++ b/windows/clist.clip
@@ -1,8 +1,0 @@
-# clist
-
-> This command is an alias of `choco list`
-> More information: https://docs.chocolatey.org/en-us/choco/commands/list
-
-- View documentation for the original command:
-
-`tldr choco list`

--- a/windows/cpush.clip
+++ b/windows/cpush.clip
@@ -1,8 +1,0 @@
-# cpush
-
-> This command is an alias of `choco push`
-> More information: https://docs.chocolatey.org/en-us/create/commands/push
-
-- See documentation for the original command:
-
-`tldr choco-push`

--- a/windows/cuninst.clip
+++ b/windows/cuninst.clip
@@ -1,8 +1,0 @@
-# cuninst
-
-> This command is an alias of `choco uninstall`
-> More information: https://docs.chocolatey.org/en-us/choco/commands/uninstall
-
-- View documentation for the original command:
-
-`tldr choco uninstall`

--- a/windows/iwr.clip
+++ b/windows/iwr.clip
@@ -1,7 +1,0 @@
-# iwr
-
-> This command is an alias of `Invoke-WebRequest` in PowerShell
-
-- View documentation for the original command:
-
-`tldr invoke-webrequest`

--- a/windows/pwsh-where.clip
+++ b/windows/pwsh-where.clip
@@ -1,8 +1,0 @@
-# where
-
-> This command is an alias of `Where-Object`
-> More information: https://learn.microsoft.com/powershell/module/microsoft.powershell.core/where-object
-
-- View documentation for the original command:
-
-`tldr Where-Object`

--- a/windows/rd.clip
+++ b/windows/rd.clip
@@ -1,8 +1,0 @@
-# rd
-
-> This command is an alias of `rmdir`
-> More information: https://learn.microsoft.com/windows-server/administration/windows-commands/rd
-
-- View documentation for the original command:
-
-`tldr rmdir`

--- a/windows/sls.clip
+++ b/windows/sls.clip
@@ -1,8 +1,0 @@
-# sls
-
-> This command is an alias of `Select-String`
-> More information: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/select-string
-
-- View documentation for the original command:
-
-`tldr where-object`


### PR DESCRIPTION
`Aliases` tag is a replacement for presenting aliases.
