### PR TITLE
Use `Internal` tag

### DIFF
--- a/common/auditd.clip
+++ b/common/auditd.clip
@@ -1,7 +1,7 @@
 # auditd
 
 > This responds to requests from the audit utility and notifications from the kernel
-> It should not be invoked manually
+> Internal: true
 > More information: https://manned.org/auditd
 
 - Start the daemon:

--- a/common/pppd.clip
+++ b/common/pppd.clip
@@ -1,7 +1,7 @@
 # pppd
 
 > Establish Point-to-Point connection to another computer
-> It should not be invoked manually
+> Internal: true
 > More information: https://ppp.samba.org/pppd.html
 
 - Start the daemon:

--- a/linux/qm-mtunnel.clip
+++ b/linux/qm-mtunnel.clip
@@ -1,7 +1,7 @@
 # qm mtunnel
 
 > Used by `qmigrate`
-> It should not be invoked manually
+> Internal: true
 > More information: https://pve.proxmox.com/pve-docs/qm.1.html
 
 - Command used by `qmigrate` during data migration from a VM to another host:


### PR DESCRIPTION
closes #37 

Done via this one-liner:

```bash
for page in {android,common,linux}/*.clip; do sed -E -i 's/^> It should not be invoked manually$/> Internal: true/' "$page"; done
```

Benefit: change warning message via render settings, without rewriting all pages.